### PR TITLE
Allow host to be unix domain socket

### DIFF
--- a/spec/classes/consul_template_spec.rb
+++ b/spec/classes/consul_template_spec.rb
@@ -20,6 +20,15 @@ describe 'consul_template', :type => :class do
     }
   end
 
+  describe 'with parameter: consul_host as unix socket' do
+    let (:params) { { :consul_host => 'unix:///path/to/socket' } }
+
+    it { should contain_concat__fragment('header').with(
+        'content' => %r{/path/to/socket\n}
+      )
+    }
+  end
+
   describe 'with parameter: consul_port' do
     let (:params) { { :consul_port => '1111' } }
 

--- a/templates/consul-template.hcl.header.erb
+++ b/templates/consul-template.hcl.header.erb
@@ -1,2 +1,2 @@
-consul = "<%= scope.lookupvar('consul_template::consul_host') %>:<%= scope.lookupvar('consul_template::consul_port') %>" # token = "abcd1234"
+consul = "<%= scope.lookupvar('consul_template::consul_host') %><% if ! scope.lookupvar('consul_template::consul_host').start_with?('unix://') %>:<%= scope.lookupvar('consul_template::consul_port') %>" # token = "abcd1234"<% end %>
 


### PR DESCRIPTION
This omits the port if `$consul_host` starts with `unix://`